### PR TITLE
wine: rebuild using brews mingw-w64

### DIFF
--- a/Formula/mingw-w64@9.rb
+++ b/Formula/mingw-w64@9.rb
@@ -214,9 +214,7 @@ class MingwW64AT9 < Formula
     EOS
 
     ENV["LC_ALL"] = "C"
-    on_macos do
-      ENV.remove_macosxsdk
-    end
+    ENV.remove_macosxsdk if OS.mac?
     target_archs.each do |arch|
       target = "#{arch}-w64-mingw32"
       outarch = (arch == "i686") ? "i386" : "x86-64"

--- a/Formula/wine.rb
+++ b/Formula/wine.rb
@@ -13,6 +13,7 @@ class Wine < Formula
   stable do
     url "https://dl.winehq.org/wine/source/7.0/wine-7.0.tar.xz"
     sha256 "5b43e27d5c085cb18f97394e46180310d5eef7c1d91c6895432a3889b2de086b"
+    revision 1
 
     resource "gecko-x86_64" do
       url "https://dl.winehq.org/wine/wine-gecko/2.47.2/wine-gecko-2.47.2-x86_64.tar.xz"
@@ -32,12 +33,13 @@ class Wine < Formula
   end
 
   depends_on "bison" => :build
-  depends_on "gcenx/wine/mingw-w64@9" => :build if Hardware::CPU.intel?
+  depends_on "mingw-w64" => :build if Hardware::CPU.intel?
   depends_on "pkg-config" => :build
   depends_on "freetype"
   depends_on "gnutls"
   depends_on "gphoto2"
   depends_on "gst-plugins-base"
+  depends_on "gst-plugins-good"
   depends_on "krb5"
   depends_on "molten-vk" if MacOS.version >= :catalina
   depends_on "sdl2"

--- a/Formula/wine.rb
+++ b/Formula/wine.rb
@@ -8,8 +8,8 @@ class Wine < Formula
   desc "Run Windows applications without a copy of Microsoft Window"
   homepage "https://www.winehq.org/"
   license "GPL-2.0-or-later"
-  head "https://source.winehq.org/git/wine.git", branch: "master"
   revision 1
+  head "https://source.winehq.org/git/wine.git", branch: "master"
 
   stable do
     url "https://dl.winehq.org/wine/source/7.0/wine-7.0.tar.xz"

--- a/Formula/wine.rb
+++ b/Formula/wine.rb
@@ -9,11 +9,11 @@ class Wine < Formula
   homepage "https://www.winehq.org/"
   license "GPL-2.0-or-later"
   head "https://source.winehq.org/git/wine.git", branch: "master"
+  revision 1
 
   stable do
     url "https://dl.winehq.org/wine/source/7.0/wine-7.0.tar.xz"
     sha256 "5b43e27d5c085cb18f97394e46180310d5eef7c1d91c6895432a3889b2de086b"
-    revision 1
 
     resource "gecko-x86_64" do
       url "https://dl.winehq.org/wine/wine-gecko/2.47.2/wine-gecko-2.47.2-x86_64.tar.xz"


### PR DESCRIPTION
brews mingw-w64 formula includes the binutils patch that fixes parallels compilation.

Added gst-plugins-good ad that’s what where including with the upstream macOS packages.