### PR TITLE
game-porting-toolkit: Avoid ld shim

### DIFF
--- a/Formula/game-porting-toolkit.rb
+++ b/Formula/game-porting-toolkit.rb
@@ -24,6 +24,7 @@ class GamePortingToolkit < Formula
   keg_only :versioned_formula
 
   depends_on "bison" => :build
+  depends_on "cctools" => :build
   depends_on "cx-llvm" => :build
   depends_on "mingw-w64" => :build
   depends_on "pkg-config" => :build
@@ -63,8 +64,10 @@ class GamePortingToolkit < Formula
     # Bypass the Homebrew shims to build native binaries with the dedicated compiler.
     # (PE binaries will be built with mingw32-gcc.)
     compiler = Formula["cx-llvm"]
+    linker = Formula["cctools"]
     compiler_options = ["CC=#{compiler.bin}/clang",
-                        "CXX=#{compiler.bin}/clang++"]
+                        "CXX=#{compiler.bin}/clang++",
+                        "LD=#{linker.bin}/ld"]
 
     # We also need to tell the linker to add Homebrew to the rpath stack.
     ENV.append "LDFLAGS", "-lSystem"

--- a/Formula/game-porting-toolkit.rb
+++ b/Formula/game-porting-toolkit.rb
@@ -67,6 +67,7 @@ class GamePortingToolkit < Formula
     linker = Formula["cctools"]
     compiler_options = ["CC=#{compiler.bin}/clang",
                         "CXX=#{compiler.bin}/clang++",
+                        "AS=#{linker.bin}/as",
                         "LD=#{linker.bin}/ld"]
 
     # We also need to tell the linker to add Homebrew to the rpath stack.


### PR DESCRIPTION
Bypassing the ld shim cctools might become useable unless something else on brew blocks it