### PR TITLE
Fix JSON syntax in cask_renames.json

### DIFF
--- a/cask_renames.json
+++ b/cask_renames.json
@@ -1,4 +1,4 @@
 {
-  "gstreamer": "gstreamer-framework"
+  "gstreamer": "gstreamer-framework",
   "unofficial-wineskin": "wineskin"
 }


### PR DESCRIPTION
This broke Homebrew in a bad way