### PR TITLE
Fix tap migration syntax to make brew happy

### DIFF
--- a/tap_migrations.json
+++ b/tap_migrations.json
@@ -1,4 +1,4 @@
 {
-  "gstreamer-runtime": "homebrew/cask"
+  "gstreamer-runtime": "homebrew/cask",
   "kegworks": "Kegworks-App/kegworks"
 }


### PR DESCRIPTION
After ea90e40 `brew upgrade` is broken with this tap.

```
Error: expected ',' or '}' after object value, got: '"kegworks": "Kegworks-App/kegwor'
```

Signed-off-by: Yurii Kolesnykov <root@yurikoles.com>
