### PR TITLE
Fix homebrew warning by using newer depends_on syntax

### DIFF
--- a/Casks/game-porting-toolkit.rb
+++ b/Casks/game-porting-toolkit.rb
@@ -19,7 +19,7 @@ cask "game-porting-toolkit" do
     "wine@devel",
     "wine@staging",
   ]
-  depends_on macos: ">= :sonoma"
+  depends_on macos: :sonoma
 
   app "Game Porting Toolkit.app"
   binary "#{appdir}/Game Porting Toolkit.app/Contents/Resources/wine/bin/wine64"


### PR DESCRIPTION
With the latest updates in Homebrew, this tap generates the following warning:

```
Warning: Calling string comparison format for `depends_on macos:` is deprecated! Use `depends_on macos: :sonoma` instead.
Please report this issue to the gcenx/homebrew-wine tap (not Homebrew/* repositories), or even better, submit a PR to fix it:
  /opt/homebrew/Library/Taps/gcenx/homebrew-wine/Casks/game-porting-toolkit.rb:22
```

This PR thus try to fix the warning by switching to the suggested syntax replacement.